### PR TITLE
updating KSA domain

### DIFF
--- a/lucidmotors/const.py
+++ b/lucidmotors/const.py
@@ -17,7 +17,8 @@ class Region(Enum):
 # their mobile apps for now.
 MOBILE_API_REGIONS = {
     Region.US: "mobile.deneb.prod.infotainment.pdx.atieva.com",
-    Region.SA: "mobile.ksap.prod.do.lucidcars.io",
+    Region.SA: "mobile.ksag.prod.do.lucidcars.io",
+    Region.ME: "mobile.ksap.prod.do.lucidcars.io",
     Region.EU: "mobile.do.prod.eu.lcid.io",
 }
 

--- a/lucidmotors/const.py
+++ b/lucidmotors/const.py
@@ -6,6 +6,7 @@ from enum import Enum
 class Region(Enum):
     US = 'us'
     SA = 'sa'
+    ME = 'me' # Middle East
     EU = 'eu'
 
     @property


### PR DESCRIPTION
the KSA domain based on my testing should be `mobile.ksag.*` and not `mobile.ksap.*`.
This is at least true for Saudi Lucid accounts when I tried mine.

When I investigated further, the ip address of `mobile.ksag.prod.do.lucidcars.io` reside in in Oracle Saudi while the `mobile.ksap.prod.do.lucidcars.io` reside in AWS Bahrain.

 This will be consistant with the number of regions in the app, which are
- North America
- Europe
- Middle East
- Saudi Arabia - Other
