### PR TITLE
Update userProfileData and logoutRequest

### DIFF
--- a/lucidmotors/gen/login_session_pb2.pyi
+++ b/lucidmotors/gen/login_session_pb2.pyi
@@ -141,8 +141,10 @@ class GetUserVehiclesResponse(_message.Message):
     def __init__(self, user_vehicle_data: _Optional[_Iterable[_Union[_vehicle_state_service_pb2.Vehicle, _Mapping]]] = ...) -> None: ...
 
 class LogoutRequest(_message.Message):
-    __slots__ = ()
-    def __init__(self) -> None: ...
+    __slots__ = ("notification_device_token",)
+    NOTIFICATION_DEVICE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    notification_device_token: str
+    def __init__(self, notification_device_token: _Optional[str] = ...) -> None: ...
 
 class LogoutResponse(_message.Message):
     __slots__ = ()

--- a/lucidmotors/gen/login_session_pb2.pyi.orig
+++ b/lucidmotors/gen/login_session_pb2.pyi.orig
@@ -141,8 +141,10 @@ class GetUserVehiclesResponse(_message.Message):
     def __init__(self, user_vehicle_data: _Optional[_Iterable[_Union[_vehicle_state_service_pb2.Vehicle, _Mapping]]] = ...) -> None: ...
 
 class LogoutRequest(_message.Message):
-    __slots__ = ()
-    def __init__(self) -> None: ...
+    __slots__ = ("notification_device_token",)
+    NOTIFICATION_DEVICE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    notification_device_token: str
+    def __init__(self, notification_device_token: _Optional[str] = ...) -> None: ...
 
 class LogoutResponse(_message.Message):
     __slots__ = ()

--- a/lucidmotors/gen/user_profile_service_pb2.pyi
+++ b/lucidmotors/gen/user_profile_service_pb2.pyi
@@ -27,11 +27,12 @@ class PhoneNumber(_message.Message):
     def __init__(self, number: _Optional[str] = ...) -> None: ...
 
 class UserProfileData(_message.Message):
-    __slots__ = ("first_name", "last_name", "email", "locale", "address", "city", "state", "postal_code", "country", "phone")
+    __slots__ = ("first_name", "last_name", "email", "locale", "photo_url", "address", "city", "state", "postal_code", "country", "phone")
     FIRST_NAME_FIELD_NUMBER: _ClassVar[int]
     LAST_NAME_FIELD_NUMBER: _ClassVar[int]
     EMAIL_FIELD_NUMBER: _ClassVar[int]
     LOCALE_FIELD_NUMBER: _ClassVar[int]
+    PHOTO_URL_FIELD_NUMBER: _ClassVar[int]
     ADDRESS_FIELD_NUMBER: _ClassVar[int]
     CITY_FIELD_NUMBER: _ClassVar[int]
     STATE_FIELD_NUMBER: _ClassVar[int]
@@ -42,13 +43,14 @@ class UserProfileData(_message.Message):
     last_name: str
     email: str
     locale: str
+    photo_url: str
     address: str
     city: str
     state: str
     postal_code: str
     country: str
     phone: PhoneNumber
-    def __init__(self, first_name: _Optional[str] = ..., last_name: _Optional[str] = ..., email: _Optional[str] = ..., locale: _Optional[str] = ..., address: _Optional[str] = ..., city: _Optional[str] = ..., state: _Optional[str] = ..., postal_code: _Optional[str] = ..., country: _Optional[str] = ..., phone: _Optional[_Union[PhoneNumber, _Mapping]] = ...) -> None: ...
+    def __init__(self, first_name: _Optional[str] = ..., last_name: _Optional[str] = ..., email: _Optional[str] = ..., locale: _Optional[str] = ..., photo_url: _Optional[str] = ..., address: _Optional[str] = ..., city: _Optional[str] = ..., state: _Optional[str] = ..., postal_code: _Optional[str] = ..., country: _Optional[str] = ..., phone: _Optional[_Union[PhoneNumber, _Mapping]] = ...) -> None: ...
 
 class SetUserProfileRequest(_message.Message):
     __slots__ = ()

--- a/lucidmotors/gen/user_profile_service_pb2.pyi.orig
+++ b/lucidmotors/gen/user_profile_service_pb2.pyi.orig
@@ -27,11 +27,12 @@ class PhoneNumber(_message.Message):
     def __init__(self, number: _Optional[str] = ...) -> None: ...
 
 class UserProfileData(_message.Message):
-    __slots__ = ("first_name", "last_name", "email", "locale", "address", "city", "state", "postal_code", "country", "phone")
+    __slots__ = ("first_name", "last_name", "email", "locale", "photo_url", "address", "city", "state", "postal_code", "country", "phone")
     FIRST_NAME_FIELD_NUMBER: _ClassVar[int]
     LAST_NAME_FIELD_NUMBER: _ClassVar[int]
     EMAIL_FIELD_NUMBER: _ClassVar[int]
     LOCALE_FIELD_NUMBER: _ClassVar[int]
+    PHOTO_URL_FIELD_NUMBER: _ClassVar[int]
     ADDRESS_FIELD_NUMBER: _ClassVar[int]
     CITY_FIELD_NUMBER: _ClassVar[int]
     STATE_FIELD_NUMBER: _ClassVar[int]
@@ -42,13 +43,14 @@ class UserProfileData(_message.Message):
     last_name: str
     email: str
     locale: str
+    photo_url: str
     address: str
     city: str
     state: str
     postal_code: str
     country: str
     phone: PhoneNumber
-    def __init__(self, first_name: _Optional[str] = ..., last_name: _Optional[str] = ..., email: _Optional[str] = ..., locale: _Optional[str] = ..., address: _Optional[str] = ..., city: _Optional[str] = ..., state: _Optional[str] = ..., postal_code: _Optional[str] = ..., country: _Optional[str] = ..., phone: _Optional[_Union[PhoneNumber, _Mapping]] = ...) -> None: ...
+    def __init__(self, first_name: _Optional[str] = ..., last_name: _Optional[str] = ..., email: _Optional[str] = ..., locale: _Optional[str] = ..., photo_url: _Optional[str] = ..., address: _Optional[str] = ..., city: _Optional[str] = ..., state: _Optional[str] = ..., postal_code: _Optional[str] = ..., country: _Optional[str] = ..., phone: _Optional[_Union[PhoneNumber, _Mapping]] = ...) -> None: ...
 
 class SetUserProfileRequest(_message.Message):
     __slots__ = ()

--- a/proto/login_session.proto
+++ b/proto/login_session.proto
@@ -84,7 +84,10 @@ message GetUserVehiclesResponse {
     repeated Vehicle user_vehicle_data = 1;
 }
 
-message LogoutRequest {}
+message LogoutRequest {
+    string notification_device_token = 1;
+}
+
 message LogoutResponse {}
 
 message RefreshNotificationTokenRequest {}

--- a/proto/user_profile_service.proto
+++ b/proto/user_profile_service.proto
@@ -20,6 +20,7 @@ message UserProfileData {
     string last_name = 2;
     string email = 3;
     string locale = 4;
+    optional string photo_url = 5;
     string address = 6;
     string city = 7;
     string state = 8;


### PR DESCRIPTION
Add photo_url to UserProfileData proto

When fetching a user’s profile with GetUserProfileRequest, the resulting data object is different from the UserData object we get from Log in.

Our proto was missing the photo_url field, which sits at numnber 5.

Without this, there was no way to get the photo_url except during log in. Now we can grab it any time, along with their other profile data.


Add notification_device_token to LogoutRequest

This is a required field for LogoutRequest to work properly.