### PR TITLE
Add missing runtime dependencies: tenacity and async_lru

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ python = "^3.12"
 grpcio = "^1.75.1"
 grpc-stubs = "^1.53.0"
 protobuf = "^6.31.1"
+tenacity = "^9.0.0"
+async-lru = "^2.0.4"
 
 [tool.poetry.group.dev.dependencies]
 rich = "^13.6.0"


### PR DESCRIPTION
`lucidmotors/__init__.py` imports `tenacity` and `async_lru`, but neither is declared in `pyproject.toml` — only `grpcio`, `grpc-stubs`, and `protobuf` are. A clean install therefore fails at import:

```
$ docker run --rm python:3.12-slim sh -c "pip install -q lucidmotors==1.4.1; python -c 'import lucidmotors'"
    from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception
ModuleNotFoundError: No module named 'tenacity'
```

With both packages installed it imports fine:

```
$ docker run --rm python:3.12-slim sh -c "pip install -q lucidmotors==1.4.1 tenacity async-lru; python -c 'import lucidmotors; print(lucidmotors.__version__)'"
1.4.1
```

This doesn't show up in a development environment, because both arrive transitively through the dev group, and it doesn't show up when upgrading over an older install either — only on a fresh one. I hit it building a container against the published package.

Both imports came in with #18; this just declares them. Versions are set to the current majors (`tenacity ^9.0.0`, `async-lru ^2.0.4`), happy to widen or narrow the constraints if you'd prefer something else.
