### PR TITLE
Add login_with_refresh_token() for token-only authentication

### DIFF
--- a/lucidmotors/__init__.py
+++ b/lucidmotors/__init__.py
@@ -563,6 +563,27 @@ class LucidAPI:
         self._user_profile = reply.user_profile
         self._vehicles = reply.user_vehicle_data
 
+    async def login_with_refresh_token(self, refresh_token: str) -> None:
+        """Authenticate using a refresh token from a previous login.
+
+        Lets a long-running application persist a session across restarts
+        without storing the account password. Lucid permits one account per
+        car and the mobile app has no secondary logins, so a stored password
+        is the primary account credential; a refresh token can be revoked
+        with "log out all devices" instead of a password change.
+
+        Note that unlike :meth:`login`, the token exchange returns only
+        session info -- no user profile and no vehicle data -- so
+        :attr:`user` stays ``None`` until you call :meth:`fetch_vehicles`
+        or log in with credentials.
+
+        :param refresh_token: a token previously obtained from
+            :attr:`refresh_token` after a successful login.
+        :raises APIError: if the token has been revoked or is invalid.
+        """
+        self._refresh_token = refresh_token
+        await self.authentication_refresh()
+
     async def set_profile_photo(self, photo_bytes: bytes) -> Optional[str]:
         """Set the logged-in user's profile photo.
 
@@ -624,6 +645,17 @@ class LucidAPI:
         this object is not used as a context manager.
         """
         await self._channel.close(None)
+
+    @property
+    def refresh_token(self) -> Optional[str]:
+        """Return the current refresh token, if authenticated.
+
+        Persist this to re-authenticate later with
+        :meth:`login_with_refresh_token` instead of storing the account
+        password. Treat it as a secret: it is a long-lived bearer credential
+        and does not appear to rotate on use.
+        """
+        return self._refresh_token
 
     @property
     def user(self) -> Optional[UserProfile]:


### PR DESCRIPTION
Currently the only public way to authenticate is `login(username, password)`, so anything that wants to keep a session across restarts has to reach into a private attribute:

```python
api = LucidAPI()
api._refresh_token = stored_token   # private
await api.authentication_refresh()
```

This adds `login_with_refresh_token(token)` and a public `refresh_token` property, so the round trip has a supported path.

**Why it matters beyond tidiness.** Lucid permits one account per car and the mobile app has no secondary logins, so a stored password is the primary account credential — it unlocks the doors and opens the frunk, and it can't be revoked without a password change. A refresh token can be revoked with "log out all devices." Letting integrations store the weaker secret is a meaningful difference for anything unattended.

**One caveat, documented in the docstring:** `GetNewJWTTokenResponse` carries only `session_info` — no `user_profile` and no `user_vehicle_data` — so `api.user` stays `None` after a token login until `fetch_vehicles()` is called. Worth knowing for downstreams that assert on `api.user` after authenticating.

Tested against a real vehicle (Gravity, `1.4.1` + this patch):

```
session valid for: 5:59:59
api.user is None (documented): True
public refresh_token property matches input: True
vehicles after fetch_vehicles(): ['TARS']
invalid token raises: APIError
```

`black --check` clean.

**A behavioural note you may want to document separately:** the refresh token does **not** appear to rotate. Three consecutive `authentication_refresh()` calls returned a byte-identical token, and replaying an earlier one still worked. That's convenient — several processes can share a stored token without coordination — but it does mean it's a long-lived bearer credential rather than a self-rotating one, and `SessionInfo` carries no expiry field for it, so its lifetime isn't discoverable from the API. I've described it that way in the property docstring; happy to soften or drop that wording if it doesn't match your understanding.
